### PR TITLE
Updated middleware logic

### DIFF
--- a/src/fetch-it.js
+++ b/src/fetch-it.js
@@ -56,7 +56,7 @@ class FetchIt {
     let promise = global.Promise.resolve(request);
     let chain = [global.fetch, undefined];
 
-    for (let middleware of this.middlewares.reverse()) {
+    for (let middleware of this.middlewares.slice(0).reverse()) {
       chain.unshift(middleware.request, middleware.requestError);
       chain.push(middleware.response, middleware.responseError);
     }


### PR DESCRIPTION
Array has to be cloned before being reversed because reverse mutates the original array https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Array/reverse.
