### PR TITLE
Removed reverse from middleware iterator

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "fetch-it",
   "version": "0.3.0",
   "description": "An extended version of window.fetch with interceptors and configurable instances",
-  "main": "dist/fetch-it.js",
+  "main": "src/fetch-it.js",
   "scripts": {
     "prepublish": "npm run build",
     "build": "rm -rf dist && $(npm bin)/webpack",

--- a/src/fetch-it.js
+++ b/src/fetch-it.js
@@ -56,7 +56,7 @@ class FetchIt {
     let promise = global.Promise.resolve(request);
     let chain = [global.fetch, undefined];
 
-    for (let middleware of this.middlewares.reverse()) {
+    for (let middleware of this.middlewares.slice(0).reverse()) {
       chain.unshift(middleware.request, middleware.requestError);
       chain.push(middleware.response, middleware.responseError);
     }

--- a/src/fetch-it.js
+++ b/src/fetch-it.js
@@ -56,7 +56,7 @@ class FetchIt {
     let promise = global.Promise.resolve(request);
     let chain = [global.fetch, undefined];
 
-    for (let middleware of this.middlewares.slice(0).reverse()) {
+    for (let middleware of this.middlewares) {
       chain.unshift(middleware.request, middleware.requestError);
       chain.push(middleware.response, middleware.responseError);
     }


### PR DESCRIPTION
Is `reverse`really needed here? As for me the later middleware is added the later `response` has to be called.
